### PR TITLE
[이슈 수정] 대시보드 수정 페이지 / 네비게이션 / 마이페이지 프로필

### DIFF
--- a/pages/dashboard/[id]/edit.tsx
+++ b/pages/dashboard/[id]/edit.tsx
@@ -5,12 +5,11 @@ import styles from "../index.module.scss";
 import NavBar from "@/src/components/nav/NavBar";
 import SideBar from "@/src/components/sidebar/SideBar";
 import BackLocation from "@/src/components/dashboard/edit/BackLocation";
-import BebridgeContainer from "@/src/components/dashboard/edit/BebridgeContainer";
+import DashboardContainer from "@/src/components/dashboard/edit/DashboardContainer";
 import DeleteContainer from "@/src/components/dashboard/edit/DeleteContainer";
 import InvitationContainer from "@/src/components/dashboard/edit/InvitationContainer";
 import MemberContainer from "@/src/components/dashboard/edit/MemberContainer";
 import { EditProvider } from "@/src/contexts/dashboard/edit/EditDashboardProvider";
-
 
 const Container = styled.div`
   width: calc(100vw * 375 / 1200);
@@ -23,7 +22,6 @@ const Container = styled.div`
 `;
 
 export default function EditPage() {
-
   const router = useRouter();
   const dashboardId = router.query.id as string;
 
@@ -39,7 +37,7 @@ export default function EditPage() {
           <div className={styles.content}>
             <Container>
               <BackLocation />
-              <BebridgeContainer dashboardId={dashboardId} />
+              <DashboardContainer dashboardId={dashboardId} />
               <MemberContainer />
               <InvitationContainer dashboardId={dashboardId} />
               <DeleteContainer dashboardId={dashboardId} />

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -28,10 +28,7 @@ export const getUser = async (): Promise<User> => {
 };
 
 // 사용자 프로필 수정 API 함수
-export const updateProfile = async (
-  nickname: string,
-  profileImage?: File
-) => {
+export const updateProfile = async (nickname: string, profileImage?: File) => {
   try {
     const accessToken = sessionStorage.getItem("accessToken");
 
@@ -43,7 +40,7 @@ export const updateProfile = async (
 
     const formData = new FormData();
     formData.append("nickname", nickname);
-    if (profileImage) {
+    if (profileImage !== undefined || profileImage) {
       formData.append("profileImageUrl", profileImage);
     }
 
@@ -57,7 +54,5 @@ export const updateProfile = async (
     return response.data;
   } catch (error) {
     console.error("프로필 업데이트 실패:", error);
-    throw error;
   }
 };
-

--- a/src/components/dashboard/edit/DashboardContainer.tsx
+++ b/src/components/dashboard/edit/DashboardContainer.tsx
@@ -20,7 +20,7 @@ const ColorTile = styled.li`
   cursor: pointer;
 `;
 
-export default function BebridgeContainer({
+export default function DashboardContainer({
   dashboardId,
 }: {
   dashboardId: string;
@@ -32,10 +32,10 @@ export default function BebridgeContainer({
   const isMessage = "변경이 완료 되었습니다.";
   const [isUpdate, setIsUpdate] = useState();
 
-  const { isBebridge, getDashboardDetail } = useEdit();
+  const { isDashboard, getDashboardDetail } = useEdit();
 
   const { title: isTitle, color: isColor }: { title?: string; color?: string } =
-    isBebridge ?? {};
+    isDashboard ?? {};
 
   // 대시보드 이름 value 저장
   const handleUpdateTitle = (e: ChangeEvent<HTMLInputElement>) => {
@@ -67,18 +67,18 @@ export default function BebridgeContainer({
 
   // 데이터 수정 후 업데이트
   useEffect(() => {
-    if (isBebridge) getDashboardDetail();
+    if (isDashboard) getDashboardDetail();
   }, [isUpdate]);
 
   // 렌더링 시 데이터 화면 출력
   useEffect(() => {
-    if (isBebridge) {
-      const { title, color }: { title: string; color: string } = isBebridge;
+    if (isDashboard) {
+      const { title, color }: { title: string; color: string } = isDashboard;
       const isColor = color.toLowerCase();
       setIsUpdateTitle(title);
       setIsUpdateColor(isColor);
     }
-  }, [isBebridge]);
+  }, [isDashboard]);
 
   // 조건에 따라 변경 버튼 활성화/비활성화
   useMemo(() => {
@@ -106,7 +106,7 @@ export default function BebridgeContainer({
       )}
       <div className={`${styles.container} ${styles.section1}`}>
         <div className={styles.head}>
-          <p className={styles.title}>비브리지</p>
+          <p className={styles.title}>{isTitle}</p>
         </div>
         <div className={styles.contents}>
           <p className={styles.title}>대시보드 이름</p>

--- a/src/components/dashboard/edit/EditPage.style.module.scss
+++ b/src/components/dashboard/edit/EditPage.style.module.scss
@@ -113,9 +113,16 @@
       }
     }
     .nickname {
+      display: flex;
+      align-items: center;
       margin-left: 12px;
       font-size: 16px;
       font-weight: 400;
+
+      img {
+        margin-top: -4px;
+        margin-left: 5px;
+      }
     }
   }
 }

--- a/src/components/dashboard/edit/EditPage.style.module.scss
+++ b/src/components/dashboard/edit/EditPage.style.module.scss
@@ -59,7 +59,7 @@
   }
 }
 
-// BebridgeContainer
+// DashboardContainer
 .contents .colorList {
   -webkit-display: flex;
   display: flex;

--- a/src/components/dashboard/edit/MemberList.tsx
+++ b/src/components/dashboard/edit/MemberList.tsx
@@ -26,7 +26,7 @@ export function MemberList({
           <ul className={styles.memberList}>
             {isMembersData &&
               isMembersData?.map((item) => {
-                const { id, email, profileImageUrl } = item;
+                const { id, email, profileImageUrl, isOwner } = item;
                 return (
                   <li key={id} className={styles.tile}>
                     <div className={styles.profileCover}>
@@ -42,11 +42,23 @@ export function MemberList({
                           email[0]
                         )}
                       </div>
-                      <p className={styles.nickname}>{item.nickname}</p>
+                      <div className={styles.nickname}>
+                        <p>{item.nickname}</p>
+                        {isOwner && (
+                          <Image
+                            src="/icons/crown.svg"
+                            width={20}
+                            height={20}
+                            alt="초대"
+                          />
+                        )}
+                      </div>
                     </div>
-                    <Button onClick={() => handleShowModal(id)} $sub>
-                      삭제
-                    </Button>
+                    {!isOwner && (
+                      <Button onClick={() => handleShowModal(id)} $sub>
+                        삭제
+                      </Button>
+                    )}
                   </li>
                 );
               })}

--- a/src/components/dashboard/edit/modal/Check.tsx
+++ b/src/components/dashboard/edit/modal/Check.tsx
@@ -36,7 +36,7 @@ export const CheckModal = ({
             {(member || invite || dashboard) && (
               <Button onClick={closeModal}>닫기</Button>
             )}
-         <Button
+            <Button
               $confirm
               onClick={() => {
                 closeModal();
@@ -50,9 +50,7 @@ export const CheckModal = ({
                   deleteDashboard?.();
                 }
               }}
-            > 
-
-
+            >
               {member || dashboard
                 ? "삭제하기"
                 : invite

--- a/src/components/mypage/avataruploader.tsx
+++ b/src/components/mypage/avataruploader.tsx
@@ -5,7 +5,7 @@ import styles from "@/pages/mypage/mypage.module.scss";
 import { StaticImport } from "next/dist/shared/lib/get-img-props";
 
 interface AvatarUploaderProps {
-  setReqImage: React.Dispatch<SetStateAction<File | string>>;
+  setReqImage: React.Dispatch<SetStateAction<File | null | undefined>>;
   isThumbnail: string | StaticImport | null;
   setIsThumbnail: React.Dispatch<SetStateAction<string | StaticImport | null>>;
 }

--- a/src/components/mypage/profilecard.tsx
+++ b/src/components/mypage/profilecard.tsx
@@ -5,77 +5,74 @@ import AvatarUploader from "./avataruploader";
 import { updateProfile } from "@/src/api/userApi";
 import axiosInstance from "@/src/api/axios";
 import { StaticImport } from "next/dist/shared/lib/get-img-props";
+import { CheckModal } from "../dashboard/edit/modal/Check";
 
 interface ProfileCardProps {
   email: string;
-  nickname: string;
-  setNickname: (nickname: string) => void;
   recentNickname: string;
   recentProfileImg: string | StaticImport | null;
 }
 
 export default function ProfileCard({
   email,
-  nickname,
-  setNickname,
   recentNickname,
   recentProfileImg,
 }: ProfileCardProps) {
-  const [reqImage, setReqImage] = useState<File | string>("");
-  const [profileImage, setProfileImage] = useState();
+  const [isModal, setIsModal] = useState<boolean>(false);
+  const isMessage = "변경이 완료 되었습니다.";
   const [isUpdate, setIsUpdate] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [reqImage, setReqImage] = useState<File | null | undefined>();
+  const [isProfileImage, setIsProfileImage] = useState();
   const [isNicknameValue, setIsNicknameValue] = useState(recentNickname);
   const [isThumbnail, setIsThumbnail] = useState(recentProfileImg);
   const [isDisabled, setIsDisabled] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
- 
 
   const handleNicknameInput = (e: ChangeEvent<HTMLInputElement>) => {
-    setNickname(e.target.value);
     setIsNicknameValue(e.target.value);
   };
 
   const handleSave = async () => {
     setLoading(true);
-    setError(null);
+    setIsModal(true);
 
-    try {
-      const response = await axiosInstance.post(
-        "/users/me/image",
-        {
-          image: reqImage,
-        },
-        {
-          headers: {
-            "Content-Type": "multipart/form-data",
+    if (reqImage !== undefined) {
+      try {
+        const response = await axiosInstance.post(
+          "/users/me/image",
+          {
+            image: reqImage,
           },
-        }
-      );
+          {
+            headers: {
+              "Content-Type": "multipart/form-data",
+            },
+          }
+        );
 
-      const { data } = response;
-      setProfileImage(data.profileImageUrl);
-
-      setIsUpdate(true);
-    } catch (err) {
-      setError("프로필 업데이트에 실패했습니다.");
-    } finally {
-      setLoading(false);
+        const { data } = response;
+        setIsProfileImage(data.profileImageUrl);
+      } catch (err) {
+        console.error(err);
+      }
     }
+    setIsUpdate(true);
   };
 
   useEffect(() => {
     if (isUpdate) {
       try {
-        updateProfile(nickname, profileImage);
-        console.log("프로필 저장 완료", { nickname, profileImage });
-        alert("프로필이 업데이트되었습니다!");
+        updateProfile(isNicknameValue, isProfileImage);
+        console.log("프로필 저장 완료", {
+          isNicknameValue,
+          profileImage: isProfileImage,
+        });
       } catch (error) {
         console.error(error);
       } finally {
         setIsUpdate(false);
         setIsDisabled(true);
+        setLoading(false);
       }
     }
   }, [isUpdate]);
@@ -83,55 +80,64 @@ export default function ProfileCard({
   useEffect(() => {
     if (
       isNicknameValue !== "" &&
-      isThumbnail !== "" &&
-      recentProfileImg !== isThumbnail &&
-      recentNickname !== isNicknameValue
+      recentNickname !== isNicknameValue &&
+      isNicknameValue !== "" &&
+      isThumbnail !== ""
     ) {
       setIsDisabled(false);
     } else if (
       isNicknameValue === "" ||
       isThumbnail === "" ||
-      recentProfileImg === isThumbnail ||
-      recentNickname === isNicknameValue
+      (isNicknameValue !== "" && isThumbnail === "") ||
+      isNicknameValue === recentNickname
     ) {
       setIsDisabled(true);
     }
-  }, [recentNickname, isNicknameValue, recentProfileImg, isThumbnail]);
+  }, [isNicknameValue, isThumbnail]);
 
   return (
-    <div className={styles.profileCard}>
-      <h2>프로필</h2>
-      <div className={styles.profileInfo}>
-        <AvatarUploader
-          setReqImage={setReqImage}
-          isThumbnail={isThumbnail}
-          setIsThumbnail={setIsThumbnail}
+    <>
+      {isModal && (
+        <CheckModal
+          isModal={isModal}
+          setIsModal={setIsModal}
+          isMessage={isMessage}
         />
-        <div className={styles.profileInputs}>
-          <div className={styles.profileInputGroup}>
-            <label>이메일</label>
-            <input type="email" value={email} disabled />
-          </div>
+      )}
+      <div className={styles.profileCard}>
+        <h2>프로필</h2>
+        <div className={styles.profileInfo}>
+          <AvatarUploader
+            setReqImage={setReqImage}
+            isThumbnail={isThumbnail}
+            setIsThumbnail={setIsThumbnail}
+          />
+          <div className={styles.profileInputs}>
+            <div className={styles.profileInputGroup}>
+              <label>이메일</label>
+              <input type="email" value={email} disabled />
+            </div>
 
-          <div className={styles.profileInputGroup}>
-            <label>닉네임</label>
-            <input
-              type="text"
-              defaultValue={recentNickname}
-              onChange={(e) => {
-                handleNicknameInput(e);
-              }}
-            />
+            <div className={styles.profileInputGroup}>
+              <label>닉네임</label>
+              <input
+                type="text"
+                defaultValue={recentNickname}
+                onChange={(e) => {
+                  handleNicknameInput(e);
+                }}
+              />
+            </div>
           </div>
         </div>
+        <button
+          onClick={handleSave}
+          className={styles.saveButton}
+          disabled={isDisabled}
+        >
+          {loading ? "저장 중" : "저장"}
+        </button>
       </div>
-      <button
-        onClick={handleSave}
-        className={styles.saveButton}
-        disabled={isDisabled}
-      >
-        {loading ? "저장 중" : "저장"}
-      </button>
-    </div>
+    </>
   );
 }

--- a/src/components/mypage/profilecard.tsx
+++ b/src/components/mypage/profilecard.tsx
@@ -79,20 +79,19 @@ export default function ProfileCard({
 
   useEffect(() => {
     if (
-      isThumbnail ||
-      (isNicknameValue !== "" &&
-        recentNickname !== isNicknameValue &&
-        isNicknameValue !== "" &&
-        isThumbnail !== "")
-    ) {
-      setIsDisabled(false);
-    } else if (
+      (recentNickname === isNicknameValue &&
+        recentProfileImg === isThumbnail) ||
       isNicknameValue === "" ||
-      isThumbnail === "" ||
-      (isNicknameValue !== "" && isThumbnail === "") ||
-      isNicknameValue === recentNickname
+      isThumbnail === ""
     ) {
       setIsDisabled(true);
+    } else if (
+      (recentNickname !== isNicknameValue &&
+        recentProfileImg !== isThumbnail) ||
+      recentNickname !== isNicknameValue ||
+      recentProfileImg !== isThumbnail
+    ) {
+      setIsDisabled(false);
     }
   }, [isNicknameValue, isThumbnail]);
 

--- a/src/components/mypage/profilecard.tsx
+++ b/src/components/mypage/profilecard.tsx
@@ -79,10 +79,11 @@ export default function ProfileCard({
 
   useEffect(() => {
     if (
-      isNicknameValue !== "" &&
-      recentNickname !== isNicknameValue &&
-      isNicknameValue !== "" &&
-      isThumbnail !== ""
+      isThumbnail ||
+      (isNicknameValue !== "" &&
+        recentNickname !== isNicknameValue &&
+        isNicknameValue !== "" &&
+        isThumbnail !== "")
     ) {
       setIsDisabled(false);
     } else if (

--- a/src/components/mypage/profilesetting.tsx
+++ b/src/components/mypage/profilesetting.tsx
@@ -16,10 +16,6 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({ user }) => {
 
   const router = useRouter();
 
-  const [nickname, setNickname] = useState("");
-
-  const [error, setError] = useState<string | null>(null);
-
   return (
     <div className={styles.global}>
       <div className={styles.profileSettings}>
@@ -28,10 +24,8 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({ user }) => {
         </button>
 
         <ProfileCard
-          nickname={nickname}
           recentNickname={recentNickname}
           email={user.email}
-          setNickname={setNickname}
           recentProfileImg={recentProfileImg}
         />
 

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -123,55 +123,60 @@ export default function NavBar() {
         </div>
         <div className={styles.rightSection}>
           {/* 대시보드 상세 및 수정 페이지에서만 활성화 02.16_혜림 */}
-          {(router.route === `/dashboard/[id]` ||
-            router.route === `/dashboard/[id]/edit`) && (
-            <>
-              <Link href={`/dashboard/${params}/edit`}>
-                <button className={styles.navButton}>
+          {createByMe &&
+            (router.route === `/dashboard/[id]` ||
+              router.route === `/dashboard/[id]/edit`) && (
+              <>
+                {router.route === `/dashboard/[id]` && (
+                  <Link href={`/dashboard/${params}/edit`}>
+                    <button className={styles.navButton}>
+                      <Image
+                        src="/icons/settings.svg"
+                        width={20}
+                        height={20}
+                        alt="설정"
+                      />
+                      관리
+                    </button>
+                  </Link>
+                )}
+                <InviteButton
+                  $nav
+                  dashboardId={params}
+                  setUpdateInvite={setUpdateInvite}
+                >
                   <Image
-                    src="/icons/settings.svg"
+                    src="/icons/add_box.svg"
                     width={20}
                     height={20}
-                    alt="설정"
+                    alt="초대"
                   />
-                  관리
-                </button>
-              </Link>
-              <InviteButton
-                $nav
-                dashboardId={params}
-                setUpdateInvite={setUpdateInvite}
-              >
-                <Image
-                  src="/icons/add_box.svg"
-                  width={20}
-                  height={20}
-                  alt="초대"
-                />
-                <div>초대하기</div>
-              </InviteButton>
-              <div>
-                {members.length > 0 ? (
-                  <div style={{ display: "flex" }}>
-                    {members.map((member: any, index: number) => (
-                      <div className={styles.memberCircle} key={member.id}>
-                        {member.profileImageUrl ? (
-                          <ProfileImage
-                            src={member.profileImageUrl}
-                            alt="프로필"
-                          />
-                        ) : (
-                          <AssigneeCircle>{member?.nickname[0]}</AssigneeCircle>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p>No members found.</p>
-                )}
-              </div>
-            </>
-          )}
+                  <div>초대하기</div>
+                </InviteButton>
+                <div>
+                  {members.length > 0 ? (
+                    <div style={{ display: "flex" }}>
+                      {members.map((member: any, index: number) => (
+                        <div className={styles.memberCircle} key={member.id}>
+                          {member.profileImageUrl ? (
+                            <ProfileImage
+                              src={member.profileImageUrl}
+                              alt="프로필"
+                            />
+                          ) : (
+                            <AssigneeCircle>
+                              {member?.nickname[0]}
+                            </AssigneeCircle>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p>No members found.</p>
+                  )}
+                </div>
+              </>
+            )}
           <div className={styles["profile-container"]} ref={dropdownRef}>
             <div className={styles.profile} onClick={toggleDropdown}>
               <span className={styles.profileIcon}>

--- a/src/contexts/dashboard/edit/EditDashboardProvider.tsx
+++ b/src/contexts/dashboard/edit/EditDashboardProvider.tsx
@@ -10,7 +10,7 @@ import axiosInstance from "../../../api/axios";
 import { useEditPagination } from "../../../hooks/dashboard/edit/useEditPagination";
 
 const EditContext = createContext({
-  isBebridge: null,
+  isDashboard: null,
   isMembers: null,
   isInvitations: null,
   memberPage: 1,
@@ -32,7 +32,7 @@ export function EditProvider({
   dashboardId: string;
 }) {
   const [values, setValues] = useState({
-    isBebridge: null,
+    isDashboard: null,
     isMembers: null,
     isInvitations: null,
   });
@@ -55,11 +55,11 @@ export function EditProvider({
 
   async function getDashboardDetail() {
     const res = await axiosInstance.get(`/dashboards/${dashboardId}`);
-    const bebridge = res.data;
+    const dashboard = res.data;
 
     setValues((prevValues) => ({
       ...prevValues,
-      isBebridge: bebridge,
+      isDashboard: dashboard,
     }));
   }
 
@@ -98,7 +98,7 @@ export function EditProvider({
   return (
     <EditContext.Provider
       value={{
-        isBebridge: values.isBebridge,
+        isDashboard: values.isDashboard,
         isMembers: values.isMembers,
         isInvitations: values.isInvitations,
         memberPage,


### PR DESCRIPTION
1. 마이페이지 프로필 변경
[수정 전]
  a. 닉네임, 이미지 모두 변경 되었을 때만 수정 가능
  b. 저장 클릭 시 alert 출력
[수정 후]
  a. 닉네임 또는 이미지 중 하나만 변경 되거나 닉네임과 이미지 모두 변경 되었을 때 수정 가능
  b. 선택된 이미지가 없을 시 변경 불가 (비어있는 값 API 전송 불가)
  c. 저장 버튼 활성화 조건 변경
  d. 저장 클릭 시 모달 출력
2. 네비게이션
[수정사항]
  a. '관리' '초대하기' 버튼은 대시보드 생성 유저에게만 활성화
  b. 대시보드 수정 페이지 내에서 '관리' 버튼 비활성화 (대시보드 수정페이지로 이동하는 버튼이므로)
3. 대시보드 수정페이지
[수정사항]
  a. 구성원 섹션의 구성원 리스트에서 대시보드 생성자는 '삭제' 버튼 비활성화 (내 계정 삭제 불가)
  b. 비브리지 명칭 -> 대시보드로 전체 변경 (디자인의 일부로 착각 했음)